### PR TITLE
Issue #24 Create rust.yml to automate building

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,29 @@
+name: Rust
+
+on:
+  push:
+    branches:
+      - main
+      - wip/**
+  pull_request:
+    branches:
+      - main
+      - wip/**
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install required system libraries (ALSA hooks)
+      run: sudo apt-get install libasound2-dev && sudo apt-get install libudev-dev
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
This is based on the default rust.yml that GitHub provides, with a few changes to get it to actually work:

- it should run on wip branches, too
- it should be able to be manually triggered
- when building, it should make sure all the required pre-requisites for an Ubuntu environment (the GitHub default?) are there. As of now, that means it needs ALSA.

Note that while the hook is there for testing, there aren't any tests yet, so the only effect of this is to build Patina.